### PR TITLE
Node support for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lexicons/
+lexicons.json

--- a/deno.lock
+++ b/deno.lock
@@ -20,6 +20,7 @@
     "npm:@atproto/lexicon@~0.4.7": "0.4.7",
     "npm:@atproto/syntax@~0.3.3": "0.3.3",
     "npm:@needle-di/core@~0.11.2": "0.11.2",
+    "npm:@types/node@*": "22.12.0",
     "npm:zod@^3.24.2": "3.24.2"
   },
   "jsr": {
@@ -152,6 +153,12 @@
     "@noble/hashes@1.7.1": {
       "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
     },
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
     "await-lock@2.2.2": {
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="
     },
@@ -172,6 +179,9 @@
       "dependencies": [
         "multiformats"
       ]
+    },
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "zod@3.24.2": {
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="

--- a/packages/core/src/dns.ts
+++ b/packages/core/src/dns.ts
@@ -1,11 +1,13 @@
 import { injectable } from "@needle-di/core";
+import { resolveTxt } from "node:dns/promises";
 
 @injectable()
 export class DnsService {
   async resolveTxt(domain: string): Promise<string[][]> {
     try {
-      return await Deno.resolveDns(domain, "TXT");
+      return await resolveTxt(domain);
     } catch (error) {
+      console.error(domain, error);
       throw new Error(`Failed to resolve TXT record for ${domain}.`, {
         cause: error,
       });

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -10,7 +10,11 @@ function assertSuccessfullResolution(
   data: Resolution,
   msg?: string,
 ): asserts data is Resolution & { success: true } {
-  assertObjectMatch(data, { success: true }, msg);
+  assertObjectMatch(
+    data,
+    { success: true },
+    `${msg ?? ""} - got - ${JSON.stringify(data)}`,
+  );
 }
 
 Deno.test("resolves uri", async () => {


### PR DESCRIPTION
Adds node support by using node stdlib, which works across Node and Deno.
